### PR TITLE
Fix force direction

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn run rome:format
+

--- a/src/experience/world/vehicle.js
+++ b/src/experience/world/vehicle.js
@@ -251,7 +251,7 @@ export default class Helicopter {
 			this.thrust.y = this.stableLift;
 		}
 
-		this.rotorPshycialBody.applyForce(this.thrust, new CANNON.Vec3());
+		this.rotorPshycialBody.applyLocalForce(this.thrust, new CANNON.Vec3());
 
 		this.experience.camera.instance.lookAt(this.vehicle.position);
 
@@ -261,8 +261,6 @@ export default class Helicopter {
 			this.v.y = 3;
 			this.v.z = 6;
 		}
-
-
 
 		this.experience.camera.instance.position.lerpVectors(
 			this.experience.camera.instance.position,


### PR DESCRIPTION
The direction of applied force is based on global axis. When the helicopter turns to a different direction, the force applied ignores the direction of the physical model which breaks the control. 

Solution:

Change the applied force to local